### PR TITLE
Add alacritty terminal config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # .dotfiles
 A collection of my personal dotfiles and scripts to install them. 
+
+## Requirements
+
+There are a few requirements in order to get my setup working nicely. They are as follows:
+
+- Alacritty (terminal)
+- FiraCode Nerd Font
+- nvim, tmux
+
+

--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -1,0 +1,10 @@
+import = [
+    "~/.config/alacritty/themes/rose-pine.toml"
+]
+
+[font]
+normal = { family = "FiraCode Nerd Font", style = "Retina" }
+size = 14.0
+
+[cursor]
+style = { shape = "Block", blinking = "On" }

--- a/config/alacritty/themes/rose-pine.toml
+++ b/config/alacritty/themes/rose-pine.toml
@@ -1,0 +1,39 @@
+[colors.primary]
+background = '#191724'
+foreground = '#e0def4'
+
+[colors.cursor]
+text = '#e0def4'
+cursor = '#524f67'
+
+[colors.vi_mode_cursor]
+text = '#e0def4'
+cursor = '#524f67'
+
+[colors.selection]
+text = '#e0def4'
+background = '#403d52'
+
+[colors.normal]
+black = '#26233a'
+red = '#eb6f92'
+green = '#31748f'
+yellow = '#f6c177'
+blue = '#9ccfd8'
+magenta = '#c4a7e7'
+cyan = '#ebbcba'
+white = '#e0def4'
+
+[colors.bright]
+black = '#6e6a86'
+red = '#eb6f92'
+green = '#31748f'
+yellow = '#f6c177'
+blue = '#9ccfd8'
+magenta = '#c4a7e7'
+cyan = '#ebbcba'
+white = '#e0def4'
+
+[colors.hints]
+start = {foreground = '#908caa', background = '#1f1d2e' }
+end = { foreground = '#6e6a86', background = '#1f1d2e' }

--- a/installers/install_alacritty.sh
+++ b/installers/install_alacritty.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Setup base .config files
+if [ -d "~/.config/alacritty" ]; then
+    mdkir ~/.config/alacritty
+fi
+cd ~/.config/alacritty
+
+# Grab zip file of nvim configs from hosted site
+wget https://kingscott.github.io/.dotfiles/alacritty.zip .
+unzip alacritty.zip 
+rm alacritty.zip 
+
+# Copy files downloaded from repo to local config directory (~/.config)
+cp -r ./alacritty/ ./ 
+


### PR DESCRIPTION
## Description

Add new config for Alacritty terminal editor. I've decided to switch away from Warp, because as I've started using Neovim, I want to start using Tmux as well. The Tmux support for Warp is no bueno, and so I'm switching to Alacritty (again). 

If I don't add the config files now, I'll forget everything. 